### PR TITLE
signers: format addresses as code

### DIFF
--- a/signers/mainnet-signers.md
+++ b/signers/mainnet-signers.md
@@ -4,17 +4,17 @@ Below is a list of the current companies signing blocks on the GoChain network.
 
 | Name | Location| Signing Address |
 | --- | --------------- | --- |
-| [**GoChain**](https://gochain.io)  | New York, United States | [0xed7f2e81b0264177e0df8f275f97fd74fa51a896](https://explorer.gochain.io/addr/0xed7f2e81b0264177e0df8f275f97fd74fa51a896) |
-| | San Francisco, United States | [0x3ad14430951aba12068a8167cebe3ddd57614432](https://explorer.gochain.io/addr/0x3ad14430951aba12068a8167cebe3ddd57614432) |
-| | New York, United States | [0x3729d2e93e8037f87a2c9afe34cb84b7069e4dea](https://explorer.gochain.io/addr/0x3729d2e93e8037f87a2c9afe34cb84b7069e4dea) |
-| | San Francisco, United States | [0xf6290b7f9f871d21317acc259f2ae23c0aa69c73](https://explorer.gochain.io/addr/0xf6290b7f9f871d21317acc259f2ae23c0aa69c73) |
-| [**Cloud Carib**](https://www.cloudcarib.com/) | Nassau, Bahamas | [0xe1200caf0d92018fe111943faf91a0c5f6db34d1](https://explorer.gochain.io/addr/0xe1200caf0d92018fe111943faf91a0c5f6db34d1) |
-| [**Procurious**](https://www.procurious.com/) | Netherlands | [0xdd9ce1d9d548d0c5ac333a1b2d2042281886c5ea](https://explorer.gochain.io/addr/0xdd9ce1d9d548d0c5ac333a1b2d2042281886c5ea) |
-| [**KuCoin**](https://kucoin.com) | Tokyo, Japan | [0x1ee4baf2cccc633b8e2c06a3ac20319610cf3cd5](https://explorer.gochain.io/addr/0x1ee4baf2cccc633b8e2c06a3ac20319610cf3cd5) |
-| [**ICOSyndicate**](https://icosyndicate.org/) | Amsterdam, Netherlands | [0x95dddf0006c6a2cae3d719efda527ce7ff8bef9c](https://explorer.gochain.io/addr/0x95dddf0006c6a2cae3d719efda527ce7ff8bef9c) |
-| [**Blockox Fund**](http://blockox.vc/) | Singapore | [0x1324567409b771d09a6abdb4af249b7fe2de45fc](https://explorer.gochain.io/addr/0x1324567409b771d09a6abdb4af249b7fe2de45fc) |
-| [**SafeContracts**](https://safecontracts.io) | Sao Paulo, Brazil | [0x76c8b15940c5b0775389d4e6adb854182930a0ee](https://explorer.gochain.io/addr/0x76c8b15940c5b0775389d4e6adb854182930a0ee) |
-| [**SheGO**](http://shego.org/) | Dublin, Ireland | [0x4ed78f888e3d8f9f50e3f23e0ff2cf55550015bd](https://explorer.gochain.io/addr/0x4ed78f888e3d8f9f50e3f23e0ff2cf55550015bd) |
-| [**Warner BP**](https://warnerbusinesspark.ca/) | Toronto, Canada | [0x48c67d87cd7d716ec044dbe33a0152557bf86062](https://explorer.gochain.io/addr/0x48c67d87cd7d716ec044dbe33a0152557bf86062) |
-| [**The Him**](http://www.thehimmusic.com/) | Netherlands | [0xd707552e5cc8e894d76fd0c82eb368c2f3a4af1a](https://explorer.gochain.io/addr/0xd707552e5cc8e894d76fd0c82eb368c2f3a4af1a) |
-| [**Primablock**](https://primablock.com/) | Paris, France | [0x22d68b3bf15b37605c29e2477ef55729593cf40a](https://explorer.gochain.io/addr/0x22d68b3bf15b37605c29e2477ef55729593cf40a) |
+| [**GoChain**](https://gochain.io)  | New York, United States | [`0xed7f2e81b0264177e0df8f275f97fd74fa51a896`](https://explorer.gochain.io/addr/0xed7f2e81b0264177e0df8f275f97fd74fa51a896) |
+| | San Francisco, United States | [`0x3ad14430951aba12068a8167cebe3ddd57614432`](https://explorer.gochain.io/addr/0x3ad14430951aba12068a8167cebe3ddd57614432) |
+| | New York, United States | [`0x3729d2e93e8037f87a2c9afe34cb84b7069e4dea`](https://explorer.gochain.io/addr/0x3729d2e93e8037f87a2c9afe34cb84b7069e4dea) |
+| | San Francisco, United States | [`0xf6290b7f9f871d21317acc259f2ae23c0aa69c73`](https://explorer.gochain.io/addr/0xf6290b7f9f871d21317acc259f2ae23c0aa69c73) |
+| [**Cloud Carib**](https://www.cloudcarib.com/) | Nassau, Bahamas | [`0xe1200caf0d92018fe111943faf91a0c5f6db34d1`](https://explorer.gochain.io/addr/0xe1200caf0d92018fe111943faf91a0c5f6db34d1) |
+| [**Procurious**](https://www.procurious.com/) | Netherlands | [`0xdd9ce1d9d548d0c5ac333a1b2d2042281886c5ea`](https://explorer.gochain.io/addr/0xdd9ce1d9d548d0c5ac333a1b2d2042281886c5ea) |
+| [**KuCoin**](https://kucoin.com) | Tokyo, Japan | [`0x1ee4baf2cccc633b8e2c06a3ac20319610cf3cd5`](https://explorer.gochain.io/addr/0x1ee4baf2cccc633b8e2c06a3ac20319610cf3cd5) |
+| [**ICOSyndicate**](https://icosyndicate.org/) | Amsterdam, Netherlands | [`0x95dddf0006c6a2cae3d719efda527ce7ff8bef9c`](https://explorer.gochain.io/addr/0x95dddf0006c6a2cae3d719efda527ce7ff8bef9c) |
+| [**Blockox Fund**](http://blockox.vc/) | Singapore | [`0x1324567409b771d09a6abdb4af249b7fe2de45fc`](https://explorer.gochain.io/addr/0x1324567409b771d09a6abdb4af249b7fe2de45fc) |
+| [**SafeContracts**](https://safecontracts.io) | Sao Paulo, Brazil | [`0x76c8b15940c5b0775389d4e6adb854182930a0ee`](https://explorer.gochain.io/addr/0x76c8b15940c5b0775389d4e6adb854182930a0ee) |
+| [**SheGO**](http://shego.org/) | Dublin, Ireland | [`0x4ed78f888e3d8f9f50e3f23e0ff2cf55550015bd`](https://explorer.gochain.io/addr/0x4ed78f888e3d8f9f50e3f23e0ff2cf55550015bd) |
+| [**Warner BP**](https://warnerbusinesspark.ca/) | Toronto, Canada | [`0x48c67d87cd7d716ec044dbe33a0152557bf86062`](https://explorer.gochain.io/addr/0x48c67d87cd7d716ec044dbe33a0152557bf86062) |
+| [**The Him**](http://www.thehimmusic.com/) | Netherlands | [`0xd707552e5cc8e894d76fd0c82eb368c2f3a4af1a`](https://explorer.gochain.io/addr/0xd707552e5cc8e894d76fd0c82eb368c2f3a4af1a) |
+| [**Primablock**](https://primablock.com/) | Paris, France | [`0x22d68b3bf15b37605c29e2477ef55729593cf40a`](https://explorer.gochain.io/addr/0x22d68b3bf15b37605c29e2477ef55729593cf40a) |


### PR DESCRIPTION
This PR wraps account addresses in code blocks so that they use a fixed width font and align with each other.