### PR TITLE
local: add NETWORK_NAME

### DIFF
--- a/private-networks/local/docker-compose.yml
+++ b/private-networks/local/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     environment:
       - PORT=80
       - WS_SECRET=ironsecret
+      - NETWORK_NAME=localnet
     network_mode: "service:node"
     depends_on:
       - node


### PR DESCRIPTION
This PR adds `NETWORK_NAME` to the local netstats compose file (a new feature from https://github.com/gochain-io/netstats/pull/52).